### PR TITLE
fix error when resetting description to none

### DIFF
--- a/Leveler/leveler.py
+++ b/Leveler/leveler.py
@@ -422,10 +422,13 @@ class Leveler(commands.Cog):
 
     @profileset.command()
     @commands.guild_only()
-    async def description(self, ctx, *, description: str = None):
+    async def description(self, ctx, *, description: str = ""):
         """Change your profile description"""
         await self.profiles._set_description(ctx.author, description)
-        await ctx.send(_("Profile description set to: ") + str(description))
+        if description == "":
+            await ctx.send(_("Cleared profile description!"))
+        else:
+            await ctx.send(_("Profile description set to: ") + str(description))
 
     @roles.command()
     @checks.mod_or_permissions(manage_messages=True)


### PR DESCRIPTION
If someone set's their profile description without any text (setting it to None) they won't be able to view their profile anymore as it try's to call functions with the profile's description, which should be a string but its None. Also made it clearer when resetting it to none.