### PR TITLE
time.perf_counter() issues, vault_updater bug fix, and moving to f-strings (amongst other cosmetic changes)

### DIFF
--- a/Leveler/leveler.py
+++ b/Leveler/leveler.py
@@ -414,7 +414,7 @@ class Leveler(commands.Cog):
         """Reset Monthly Leaderboard. NOTE THIS CANNOT BE UNDONE"""
         if confirm != 'MONTHLY LEADERBOARD RESET CONFIRM':
             return await ctx.send("Please run the command `!levelerset resetmonthly MONTHLY LEADERBOARD RESET CONFIRM`")
-        await self._reset_monthly()
+        await self.profiles._reset_monthly()
 
     @levelerset.group()
     @checks.mod_or_permissions(manage_messages=True)

--- a/Leveler/leveler.py
+++ b/Leveler/leveler.py
@@ -91,6 +91,15 @@ class Leveler(commands.Cog):
         except:
             pass
 
+    @commands.command()
+    async def monthlyexp(self, ctx, member: discord.Member = None):
+        """Get your monthly exp"""
+        if member is None:
+            member = ctx.member
+        exp = self._get_monthly_exp(member)
+        await ctx.send(f'{member.display_name}\'s monthly xp is: {exp}')
+
+
     @commands.command(hidden=True)
     @checks.is_owner()
     async def testreset(self, ctx):

--- a/Leveler/userprofile.py
+++ b/Leveler/userprofile.py
@@ -168,6 +168,9 @@ class UserProfile:
     async def _get_exp(self, member):
         return await self.data.member(member).exp()
 
+    async def _get_monthly_exp(self, member):
+        return await self.data.member(member).monthlyexp()
+
     async def _get_level(self, member):
         return await self.data.member(member).level()
 

--- a/heist/heist.py
+++ b/heist/heist.py
@@ -49,13 +49,13 @@ class Heist(commands.Cog):
         """Clears a member of jail and death statuses."""
         author = ctx.message.author
         await self.thief.member_clear(user)
-        await ctx.send("```{} administratively cleared {}```".format(author.name, user.name))
+        await ctx.send(f"```{author.name} administratively cleared {user.name}```")
 
     @heist.command(name="version")
     @checks.admin_or_permissions(manage_guild=True)
     async def _version_heist(self, ctx):
         """Shows the version of heist you are running"""
-        await ctx.send("You are running v3 Heist version {}.".format(self.version))
+        await ctx.send(f"You are running v3 Heist version {self.version}.")
 
     @heist.command(name="targets")
     async def _targets_heist(self, ctx):
@@ -66,8 +66,7 @@ class Heist(commands.Cog):
         t_vault = theme["Vault"]
 
         if len(targets.keys()) < 0:
-            msg = ("There aren't any targets! To create a target use {}heist "
-                   "createtarget .".format(ctx.prefix))
+            msg = (f"There aren't any targets! To create a target use ```{ctx.prefix}heist createtarget```.")
         else:
             target_names = [x for x in targets]
             crews = [int(subdict["Crew"]) for subdict in targets.values()]
@@ -76,7 +75,7 @@ class Heist(commands.Cog):
             data = list(zip(target_names, crews, vaults, success))
             table_data = sorted(data, key=itemgetter(1), reverse=True)
             table = tabulate(table_data, headers=["Target", "Max Crew", t_vault, "Success Rate"])
-            msg = "```C\n{}```".format(table)
+            msg = f"```C\n{table}```"
 
         await ctx.send(msg)
 
@@ -95,20 +94,20 @@ class Heist(commands.Cog):
             player = user
 
         if await self.thief.get_member_status(player) != "Apprehended":
-            return await ctx.send("{} is not in jail.".format(player.display_name))
+            return await ctx.send(f"{player.display_name} is not in jail.")
 
         cost = await self.thief.get_member_bailcost(player)
         if not await bank.get_balance(player) >= cost:
-            await ctx.send("You do not have enough to afford the {} amount.".format(t_bail))
+            await ctx.send(f"You do not have enough to afford the {t_bail} amount.")
             return
 
         if player.id == author.id:
-            msg = ("Do you want to make a {0} amount? It will cost {1} credits. If you are "
-                   "caught again, your next {2} and {0} amount will triple. "
-                   "Do you still wish to pay the {0} amount?".format(t_bail, cost, t_sentence))
+            msg = (f"Do you want to make a {t_bail} amount? It will cost {cost} credits. If you are "
+                   f"caught again, your next {t_sentence} and {t_bail} amount will triple. "
+                   f"Do you still wish to pay the {t_bail} amount?")
         else:
-            msg = ("You are about pay a {2} amount for {0} and it will cost you {1} credits. "
-                   "Are you sure you wish to pay {1} for {0}?".format(player.name, cost, t_bail))
+            msg = (f"You are about pay a {t_bail} amount for {player.name} and it will cost you {cost} credits. "
+                   f"Are you sure you wish to pay {cost} for {player.name}?")
 
         await ctx.send(msg)
         response = await self.bot.wait_for('MESSAGE', timeout=15, check=lambda x: x.author == author)
@@ -118,11 +117,11 @@ class Heist(commands.Cog):
             return
 
         if "yes" in response.content.lower():
-            msg = ("Congratulations {}, you are free! Enjoy your freedom while it "
-                   "lasts...".format(player.display_name))
+            msg = (f"Congratulations {player.display_name}, you are free! Enjoy your freedom while it "
+                   f"lasts...")
             await bank.withdraw_credits(author, cost)
             await self.thief.set_member_free(author)
-            await self.thief.set_member_oob(author, False)
+            await self.thief.set_member_oob(author, True)
         elif "no" in response.content.lower():
             msg = "Canceling transaction."
         else:
@@ -139,9 +138,9 @@ class Heist(commands.Cog):
         guild = ctx.guild
         cancel = ctx.prefix + "cancel"
         check = lambda m: m.author == author and (m.content.isdigit() and int(m.content) > 0 or m.content == cancel)
-        start = ("This will walk-through the target creation process. You may cancel this process "
-                 "at anytime by typing {}cancel. Let's begin with the first question.\nWhat is the "
-                 "name of this target?".format(ctx.prefix))
+        start = (f"This will walk-through the target creation process. You may cancel this process "
+                 f"at anytime by typing ```{cancel}```. Let's begin with the first question.\nWhat is the "
+                 f"name of this target?")
 
         await ctx.send(start)
         name = await self.bot.wait_for('MESSAGE', timeout=35, check=lambda x: x.author == author)
@@ -211,11 +210,8 @@ class Heist(commands.Cog):
             await ctx.send("Target creation cancelled.")
             return
         else:
-            msg = ("Target Created.\n```Name:       {}\nGroup:      {}\nVault:      {}\nVault Max: "
-                   " {}\nSuccess:    {}%```".format(string.capwords(name.content), crew.content,
-                                                    vault.content, vault_max.content,
-                                                    success.content)
-                   )
+            msg = (f"Target Created.\n```Name:       {string.capwords(name.content)}\nGroup:      {crew.content}\nVault:      {vault.content}\nVault Max: "
+                   f" {vault_max.content}\nSuccess:    {success.content}%```")
             target_fmt = {"Crew": int(crew.content), "Vault": int(vault.content),
                           "Vault Max": int(vault_max.content), "Success": int(success.content)}
             targets[string.capwords(name.content)] = target_fmt
@@ -238,8 +234,8 @@ class Heist(commands.Cog):
         keys.append("Name")
         check = lambda m: m.content.title() in keys and m.author == author
 
-        await ctx.send("Which property of {} would you like to edit?\n"
-                           "{}".format(target, ", ".join(keys)))
+        await ctx.send(f"Which property of {target} would you like to edit?\n"
+                       f"{', '.join(keys)}")
 
         response = await self.bot.wait_for('MESSAGE', timeout=15, check=check)
 
@@ -252,8 +248,7 @@ class Heist(commands.Cog):
             check2 = lambda m: string.capwords(m.content) not in targets and m.author == author
 
         elif response.content.title() in ["Vault", "Vault Max"]:
-            await ctx.send("What would you like to set the {} "
-                               "to?".format(response.content.title()))
+            await ctx.send(f"What would you like to set the {response.content.title()} to?")
             check2 = lambda m: m.content.isdigit() and int(m.content) > 0 and m.author == author
 
         elif response.content.title() == "Success":
@@ -276,13 +271,11 @@ class Heist(commands.Cog):
             new_name = string.capwords(choice.content)
             targets[new_name] = targets.pop(target)
             await self.thief.save_targets(guild, targets)
-            await ctx.send("Changed {}'s {} to {}.".format(target, response.content,
-                                                               choice.content))
+            await ctx.send(f"Changed {target}'s {response.content} to {choice.content}.")
         else:
             targets[target][response.content.title()] = int(choice.content)
             await self.thief.save_targets(guild, targets)
-            await ctx.send("Changed {}'s {} to {}.".format(target, response.content,
-                                                               choice.content))
+            await ctx.send(f"Changed {target}'s {response.content} to {choice.content}.")
 
     @heist.command(name="remove")
     @checks.admin_or_permissions(manage_guild=True)
@@ -292,15 +285,14 @@ class Heist(commands.Cog):
         guild = ctx.guild
         targets = await self.thief.get_guild_targets(guild)
         if string.capwords(target) in targets:
-            await ctx.send("Are you sure you want to remove {} from the list of "
-                               "targets?".format(string.capwords(target)))
+            await ctx.send(f"Are you sure you want to remove {string.capwords(target)} from the list of targets?")
             response = await self.bot.wait_for('MESSAGE', timeout=15, check=lambda x: x.author == author)
             if response is None:
                 msg = "Canceling removal. You took too long."
             elif response.content.title() == "Yes":
                 targets.pop(string.capwords(target))
                 await self.thief.save_targets(guild, targets)
-                msg = "{} was removed from the list of targets.".format(string.capwords(target))
+                msg = f"{string.capwords(target)} was removed from the list of targets."
             else:
                 msg = "Canceling target removal."
         else:
@@ -329,16 +321,16 @@ class Heist(commands.Cog):
         time_values = [config["Wait"], config["Police"],
                        config["Sentence"], config["Death"]]
         timers = list(map(self.thief.time_format, time_values))
-        description = ["Heist Version {}".format(self.version), "Theme: {}".format(theme)]
+        description = [f"Heist Version {self.version}", f"Theme: {theme}"]
         footer = "Heist was developed by Redjumpman for Red Bot v2.\nUpdated to v3 by Malarne"
 
         embed = discord.Embed(colour=0x0066FF, description="\n".join(description))
-        embed.title = "{} Heist Settings".format(guild.name)
+        embed.title = f"{guild.name} Heist Settings"
         embed.add_field(name="Heist Cost", value=config["Cost"])
-        embed.add_field(name="Base {} Cost".format(t_bail), value=config["Bail"])
+        embed.add_field(name=f"Base {t_bail} Cost", value=config["Bail"])
         embed.add_field(name="Crew Gather Time", value=timers[0])
-        embed.add_field(name="{} Timer".format(t_police), value=timers[1])
-        embed.add_field(name="Base {} {}".format(t_jail, t_sentence), value=timers[2])
+        embed.add_field(name=f"{t_police} Timer", value=timers[1])
+        embed.add_field(name=f"Base {t_jail} {t_sentence}", value=timers[2])
         embed.add_field(name="Death Timer", value=timers[3])
         embed.add_field(name="Hardcore Mode", value=hardcore)
         embed.set_footer(text=footer)
@@ -360,14 +352,14 @@ class Heist(commands.Cog):
         t_sentence = theme["Sentence"]
 
         if await self.thief.get_member_status(author) != "Apprehended" or oob:
-            await ctx.send("I can't remove you from {0} if you're not "
-                               "*in* {0}.".format(t_jail))
+            await ctx.send(f"I can't remove you from {t_jail} if you're not "
+                           f"*in* {t_jail}.")
             return
 
         remaining = self.thief.cooldown_calculator(player_time, base_time)
         if remaining != "No Cooldown":
-            await ctx.send("You still have time on your {}. You still need to wait:\n"
-                               "```{}```".format(t_sentence, remaining))
+            await ctx.send(f"You still have time on your {t_sentence}. You still need to wait:\n"
+                           f"```{remaining}```")
             return
 
         msg = "You served your time. Enjoy the fresh air of freedom while you can."
@@ -397,8 +389,8 @@ class Heist(commands.Cog):
                 await self.thief.set_member_free(author)
                 msg = "You have risen from the dead!"
             else:
-                msg = ("You can't revive yet. You still need to wait:\n"
-                       "```{}```".format(remainder))
+                msg = (f"You can't revive yet. You still need to wait:\n"
+                       f"```{remainder}```")
         else:
             msg = "You still have a pulse. I can't revive someone who isn't dead."
         await ctx.send(msg)
@@ -415,8 +407,8 @@ class Heist(commands.Cog):
         await self.thief.check_member_settings(author)
 
         # Theme variables
-        sentencing = "{} {}".format(theme["Jail"], theme["Sentence"])
-        t_bail = "{} Cost".format(theme["Bail"])
+        sentencing = f"{theme['Jail']} {theme['Sentence']}"
+        t_bail = f"{theme['Bail']} Cost"
 
         # Sentence Time Remaining
         sentence = await self.thief.get_member_sentence(author)
@@ -471,31 +463,33 @@ class Heist(commands.Cog):
         if outcome == "Failed":
             return await ctx.send(msg)
 
+        unique_id = f'{author.name}:{author.id}'
         if not config["Planned"]:
             await bank.withdraw_credits(author, cost)
             config["Planned"] = True
+            config["Heist author"] = unique_id
             await self.thief.config.guild(guild).Config.set(config)
             crew = await self.thief.add_crew_member(author)
-            await ctx.send("A {4} is being planned by {0}\nThe {4} "
-                               "will begin in {1} seconds. Type {2}heist play to join their "
-                               "{3}.".format(author.name, wait_time, ctx.prefix, t_crew, t_heist))
+            await ctx.send(f"A {t_heist} is being planned by {author.name}\nThe {t_heist} "
+                           f"will begin in {wait_time} seconds. Type ```{ctx.prefix}heist play``` to join their "
+                           f"{t_crew}.")
             await asyncio.sleep(wait_time)
             
             crew = await self.thief.config.guild(guild).Crew()
 
             if len(crew) <= 1:
-                await ctx.send("You tried to rally a {}, but no one wanted to follow you. The "
-                                   "{} has been cancelled.".format(t_crew, t_heist))
+                await ctx.send(f"You tried to rally a {t_crew}, but no one wanted to follow you. The "
+                               f"{t_heist} has been cancelled.")
                 await self.thief.reset_heist(guild)
             else:
                 await self.heist_game(ctx, guild, t_heist, t_crew, t_vault)
-
+        elif unique_id == config["Heist author"]:
+                await ctx.send(f"Hey {author.name}! You are already in your own {t_crew} to perform your nefarious {t_heist}! Unless you are his evil twin!?")
         else:
             await bank.withdraw_credits(author, cost)
             crew = await self.thief.add_crew_member(author)
             crew_size = len(crew)
-            await ctx.send("{0} has joined the {2}.\nThe {2} now has {1} "
-                               "members.".format(author.display_name, crew_size, t_crew))
+            await ctx.send(f"{author.display_name} has joined the {t_crew}.\nThe {t_crew} now has {crew_size} members.")
 
     async def heist_game(self, ctx, guild, t_heist, t_crew, t_vault):
         config = await self.thief.get_guild_settings(guild)
@@ -508,8 +502,8 @@ class Heist(commands.Cog):
         players = [guild.get_member(int(x)) for x in curcrew]
         results = await self.thief.game_outcomes(guild, players, target)
         start_output = await self.thief.message_handler(guild, crew, players)
-        await ctx.send("Get ready! The {} is starting with {}\nThe {} has decided to "
-                           "hit **{}**.".format(t_heist, start_output, t_crew, target))
+        await ctx.send(f"Get ready! The {t_heist} is starting with {start_output}\nThe {t_crew} has decided to "
+                       f"hit **{target}**.")
         await asyncio.sleep(2)
         await self.thief.show_results(ctx, guild, results)
         curcrew = await self.thief.get_guild_crew(guild)
@@ -518,11 +512,11 @@ class Heist(commands.Cog):
             data = await self.thief.calculate_credits(guild, players, target)
             headers = ["Players", "Credits Obtained", "Bonuses", "Total"]
             t = tabulate(data, headers=headers)
-            msg = ("The credits collected from the {} was split among the winners:\n```"
-                   "C\n{}```".format(t_vault, t))
+            msg = (f"The credits collected from the {t_vault} was split among the winners:\n```"
+                   f"C\n{t}```")
         else:
             msg = "No one made it out safe."
-        config["Alert"] = int(time.perf_counter())
+        config["Alert"] = int(time.time())
         await self.thief.config.guild(guild).Config.set(config)
         await self.thief.reset_heist(guild)
         await ctx.send(msg)
@@ -535,7 +529,8 @@ class Heist(commands.Cog):
                   for x in os.listdir(str(bundled_data_path(self))) if x.endswith(".txt")]
         if len(themes) > 30:
             themes = themes[:30]
-        await ctx.send("Available Themes:```\n{}```".format('\n'.join(themes)))
+        theme_per_line = '\n'.join(themes) # because f-string cannot have backslashes
+        await ctx.send(f"Available Themes:```\n{theme_per_line}```")
 
     @heist.command(name="theme")
     @checks.admin_or_permissions(manage_guild=True)
@@ -544,17 +539,16 @@ class Heist(commands.Cog):
         theme = theme.title()
         guild = ctx.guild
 
-        if not os.path.exists(str(bundled_data_path(self)) + "/{}.txt".format(theme)):
+        if not os.path.exists(str(bundled_data_path(self)) + f"/{theme}.txt"):
             themes = [os.path.join(x).replace('.txt', '')
                       for x in os.listdir(str(bundled_data_path(self))) if x.endswith(".txt")]
-            msg = ("I could not find a theme with that name. Available Themes:"
-                   "```\n{}```".format('\n'.join(themes)))
+            theme_per_line = '\n'.join(themes) # because f-string cannot have backslashes
+            msg = (f"I could not find a theme with that name. Available Themes:"
+                   f"```\n{theme_per_line}```")
         else:
             msg = await self.thief.theme_loader(guild, theme)
 
         await ctx.send(msg)
-
-
 
     @commands.group(no_pm=True)
     async def setheist(self, ctx):
@@ -580,7 +574,7 @@ class Heist(commands.Cog):
 
         settings["Crew"] = output.title()
         await self.thief.config.guild(guild).Config.set(settings)
-        await ctx.send("Now setting the message output type to {}.".format(output))
+        await ctx.send(f"Now setting the message output type to {output}.")
 
     @setheist.command(name="sentence")
     @checks.admin_or_permissions(manage_guild=True)
@@ -596,7 +590,7 @@ class Heist(commands.Cog):
             config["Sentence"] = seconds
             await self.thief.config.guild(guild).Config.set(config)
             time_fmt = self.thief.time_format(seconds)
-            msg = "Setting base {} {} to {}.".format(t_jail, t_sentence, time_fmt)
+            msg = f"Setting base {t_jail} {t_sentence} to {time_fmt}."
         else:
             msg = "Need a number higher than 0."
         await ctx.send(msg)
@@ -611,7 +605,7 @@ class Heist(commands.Cog):
         if cost >= 0:
             config["Cost"] = cost
             await self.thief.config.guild(guild).Config.set(config)
-            msg = "Setting heist cost to {}.".format(cost)
+            msg = f"Setting heist cost to {cost}."
         else:
             msg = "Need a number higher than -1."
         await ctx.send(msg)
@@ -629,7 +623,7 @@ class Heist(commands.Cog):
             config["Police"] = seconds
             await self.thief.config.guild(guild).Config.set(config)
             time_fmt = self.thief.time_format(seconds)
-            msg = "Setting {} alert time to {}.".format(t_police, time_fmt)
+            msg = f"Setting {t_police} alert time to {time_fmt}."
         else:
             msg = "Need a number higher than 0."
         await ctx.send(msg)
@@ -645,7 +639,7 @@ class Heist(commands.Cog):
         if cost >= 0:
             config["Bail Base"] = cost
             await self.thief.config.guild(guild).Config.set(config)
-            msg = "Setting base {} cost to {}.".format(t_bail, cost)
+            msg = f"Setting base {t_bail} cost to {cost}."
         else:
             msg = "Need a number higher than -1."
         await ctx.send(msg)
@@ -661,7 +655,7 @@ class Heist(commands.Cog):
             config["Death"] = seconds
             await self.thief.config.guild(guild).Config.set(config)
             time_fmt = self.thief.time_format(seconds)
-            msg = "Setting death timer to {}.".format(time_fmt)
+            msg = f"Setting death timer to {time_fmt}."
         else:
             msg = "Need a number higher than 0."
         await ctx.send(msg)
@@ -695,7 +689,7 @@ class Heist(commands.Cog):
             config["Wait"] = seconds
             await self.thief.config.guild(guild).Config.set(config)
             time_fmt = self.thief.time_format(seconds)
-            msg = "Setting {} gather time to {}.".format(t_crew, time_fmt)
+            msg = f"Setting {t_crew} gather time to {time_fmt}."
         else:
             msg = "Need a number higher than 0."
         await ctx.send(msg)


### PR DESCRIPTION
  Switched to time.time() as time.perf_counter() is not supposed to be
  persisted and checked again after long (>1min) periods of time
- Fixed oob not being set to True when a player was bailed out
- Fixed cosmetic issue when player_time is 0 (should be checked first)
- Added a unique_id for !heist play, to fix a small issue where if a player started a heist, and then
    immediately did !heist play again, he would be added to his own
    heist as if he was a crew member
- Added f-strings everywhere to make code more readable
- Fixed bug on vaulter_updater (it was trying to access the key which is
  a string as if it was the dictionary)