### PR TITLE
Update requirements for Leveler

### DIFF
--- a/Leveler/info.json
+++ b/Leveler/info.json
@@ -5,7 +5,7 @@
   "hidden": false,
   "install_msg": "Thank you for installing this leveler !\nPlease consult the docs at https://discord-cogs.readthedocs.io/en/latest/leveler.html for setup informations.\nPlease note that this cog come with bundled data, mostly the font for profile image.",
   "required_cogs": {},
-  "requirements": ["pillow"],
+  "requirements": ["Pillow==5.3.0"],
   "short": "Leveler tool, better than MEE6",
   "tags": ["leveler", "pillow", "fun"]
 }


### PR DESCRIPTION
The requirements key in `info.json` accepts whatever pip can accept, so I've adjusted it to install the correct version.